### PR TITLE
Fixed JsonProperty attribute argument of BaseAuthModel.Username

### DIFF
--- a/Assets/pocketbase-unity/Runtime/Dtos/BaseAuthModel.cs
+++ b/Assets/pocketbase-unity/Runtime/Dtos/BaseAuthModel.cs
@@ -12,7 +12,7 @@ namespace PocketBaseSdk
         [JsonProperty("emailVisibility")]
         public bool? EmailVisibility { get; private set; }
 
-        [JsonProperty("username")]
+        [JsonProperty("name")]
         public string Username { get; private set; }
 
         [JsonProperty("verified")]

--- a/Assets/pocketbase-unity/package.json
+++ b/Assets/pocketbase-unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sov3rain.pocketbase-unity",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "displayName": "PocketBase SDK",
   "description": "PocketBase Unity SDK",
   "unity": "2022.3",


### PR DESCRIPTION
I noticed that my PocketBase instance (version 0.25.8) returns the username in the JSON response as `name` rather than `username` when authenticating with a password.

I'm not sure if this has always been the case or if it was changed in a recent update to PocketBase.