### PR TITLE
fix: preserve realtime reconnect flow after idle timeout

### DIFF
--- a/Assets/Samples/Scripts/PocketBaseExamples.cs
+++ b/Assets/Samples/Scripts/PocketBaseExamples.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using PocketBaseSdk;
 using TMPro;
@@ -37,6 +36,12 @@ public class PocketBaseExamples : MonoBehaviour
         });
     }
 
+    [ContextMenu(nameof(DisconnectFromCollectionSSE))]
+    private async void DisconnectFromCollectionSSE()
+    {
+        await _pb.Collection("example").Unsubscribe("*");
+    }
+    
     [ContextMenu(nameof(HealthCheck))]
     public async void HealthCheck()
     {

--- a/Assets/pocketbase-unity/Runtime/Services/RealtimeService.cs
+++ b/Assets/pocketbase-unity/Runtime/Services/RealtimeService.cs
@@ -320,14 +320,6 @@ namespace PocketBaseSdk
                 }
             };
 
-            _sse.OnError += e =>
-            {
-                if (!completer.Task.IsCompleted)
-                {
-                    completer.TrySetException(new Exception("failed to establish SSE connection", e));
-                }
-            };
-
             _sse.Connect();
 
             return completer.Task;

--- a/Assets/pocketbase-unity/Runtime/Services/RealtimeService.cs
+++ b/Assets/pocketbase-unity/Runtime/Services/RealtimeService.cs
@@ -280,7 +280,7 @@ namespace PocketBaseSdk
 
                 if (!completer.Task.IsCompleted)
                 {
-                    completer.SetException(new Exception("failed to establish SSE connection"));
+                    completer.TrySetException(new Exception("failed to establish SSE connection"));
                 }
             };
             _sse.OnError += _ =>
@@ -316,14 +316,16 @@ namespace PocketBaseSdk
 
                 if (!completer.Task.IsCompleted)
                 {
-                    completer.SetResult(true);
+                    completer.TrySetResult(true);
                 }
             };
 
             _sse.OnError += e =>
             {
-                Disconnect();
-                completer.SetException(new Exception("failed to establish SSE connection", e));
+                if (!completer.Task.IsCompleted)
+                {
+                    completer.TrySetException(new Exception("failed to establish SSE connection", e));
+                }
             };
 
             _sse.Connect();

--- a/Assets/pocketbase-unity/Runtime/Sse/SseClient.cs
+++ b/Assets/pocketbase-unity/Runtime/Sse/SseClient.cs
@@ -26,6 +26,7 @@ namespace PocketBaseSdk
         private int _retryAttempts;
         private Coroutine _connectionCoroutine;
         private bool _isClosed;
+        private bool _receivedAnyMessage;
 
         public SseClient(
             string url,
@@ -50,6 +51,7 @@ namespace PocketBaseSdk
                 CoroutineRunner.StopCoroutine(_connectionCoroutine);
             }
 
+            CleanupRequest();
             _connectionCoroutine = CoroutineRunner.StartCoroutine(ConnectCoroutine());
         }
 
@@ -60,8 +62,7 @@ namespace PocketBaseSdk
 
             _isClosed = true;
             _sseMessage = null;
-            _request?.Dispose();
-            _request = null;
+            CleanupRequest();
 
             Application.quitting -= Close;
 
@@ -80,6 +81,7 @@ namespace PocketBaseSdk
         private IEnumerator ConnectCoroutine()
         {
             _sseMessage = new SseMessage();
+            _receivedAnyMessage = false;
             _request = new UnityWebRequest(_url);
 
             foreach (var (key, value) in _customHeaders)
@@ -99,26 +101,49 @@ namespace PocketBaseSdk
                 yield return null;
             }
 
-            if (_request.result is ConnectionError or ProtocolError)
+            if (_isClosed)
             {
-                WebException webEx = new(
-                    $"{_request.result}: {_request.error} ({_url})",
-                    _request.result switch
-                    {
-                        ConnectionError => WebExceptionStatus.ConnectFailure,
-                        ProtocolError => WebExceptionStatus.ProtocolError,
-                        _ => WebExceptionStatus.UnknownError
-                    }
-                );
-
-                OnError?.Invoke(webEx);
-
-                yield return Reconnect(_sseMessage.Retry);
+                CleanupRequest();
+                yield break;
             }
+
+            var requestResult = _request.result;
+            var requestError = _request.error;
+            int retryTimeout = _sseMessage?.Retry ?? 0;
+
+            if (_receivedAnyMessage)
+            {
+                _retryAttempts = 0;
+            }
+
+            CleanupRequest();
+
+            if (requestResult == Success)
+            {
+                OnError?.Invoke(null);
+                yield return Reconnect(retryTimeout);
+                yield break;
+            }
+
+            WebException webEx = new(
+                $"{requestResult}: {requestError} ({_url})",
+                requestResult switch
+                {
+                    ConnectionError => WebExceptionStatus.ConnectFailure,
+                    ProtocolError => WebExceptionStatus.ProtocolError,
+                    DataProcessingError => WebExceptionStatus.ReceiveFailure,
+                    _ => WebExceptionStatus.UnknownError
+                }
+            );
+
+            OnError?.Invoke(webEx);
+
+            yield return Reconnect(retryTimeout);
         }
 
         private void OnMessageReceived(SseMessage sseMessage)
         {
+            _receivedAnyMessage = true;
             _sseMessage = sseMessage;
             OnMessage?.Invoke(sseMessage);
         }
@@ -134,8 +159,6 @@ namespace PocketBaseSdk
                 yield break;
             }
 
-            Debug.Log($"Retrying in {retryTimeout} ms");
-
             if (retryTimeout <= 0)
             {
                 if (_retryAttempts > _defaultRetryTimeouts.Count - 1)
@@ -144,11 +167,19 @@ namespace PocketBaseSdk
                     retryTimeout = _defaultRetryTimeouts[_retryAttempts];
             }
 
+            Debug.Log($"Retrying in {retryTimeout} ms");
+
             float retryTimeoutSeconds = retryTimeout / 1000f;
             yield return new WaitForSeconds(retryTimeoutSeconds);
 
             _retryAttempts++;
             Connect();
+        }
+
+        private void CleanupRequest()
+        {
+            _request?.Dispose();
+            _request = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- reconnect the SSE client on transport errors and on graceful stream termination
- keep the initial realtime connection pending until the first `PB_CONNECT` instead of failing on reconnectable transport errors
- keep subscription resubmission working on the next `PB_CONNECT`
- add a sample `DisconnectFromCollectionSSE()` action to make manual connect/disconnect testing easier

## Details
PocketBase closes idle realtime SSE connections after 5 minutes by design. The Unity SDK was reconnecting only on transport errors, so an idle graceful stream termination could end the SSE request silently without reopening it.

This update aligns the runtime behavior more closely with the official Dart SDK:
- graceful SSE termination now triggers a reconnect attempt
- transport errors remain reconnectable
- `RealtimeService.Connect()` no longer fails before the first `PB_CONNECT` on recoverable transport interruptions
- retry logging now prints the actual delay used after fallback

## Fixes
- fixes #7

## Validation
- manually validated against a PocketBase test instance: no exception after idle timeout, disconnect observed, reconnect behavior fixed
- patch scope committed in this PR: `Assets/pocketbase-unity/Runtime/Sse/SseClient.cs`, `Assets/pocketbase-unity/Runtime/Services/RealtimeService.cs`, `Assets/Samples/Scripts/PocketBaseExamples.cs`